### PR TITLE
Add all base16 256 color scheme from chriskempson/base16-xresources

### DIFF
--- a/app/src/main/assets/colors/base16-3024-dark-256.properties
+++ b/app/src/main/assets/colors/base16-3024-dark-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-3024.dark.256.xresources
+# Base16 3024
+# Scheme: Jan T. Sott (http://github.com/idleberg)
+foreground=#a5a2a2
+background=#090300
+cursorColor=#a5a2a2
+
+color0=#090300
+color1=#db2d20
+color2=#01a252
+color3=#fded02
+color4=#01a0e4
+color5=#a16a94
+color6=#b5e4f4
+color7=#a5a2a2
+color8=#5c5855
+color9=#db2d20
+color10=#01a252
+color11=#fded02
+color12=#01a0e4
+color13=#a16a94
+color14=#b5e4f4
+color15=#f7f7f7
+
+color16=#e8bbd0
+color17=#cdab53
+color18=#3a3432
+color19=#4a4543
+color20=#807d7c
+color21=#d6d5d4

--- a/app/src/main/assets/colors/base16-3024-light-256.properties
+++ b/app/src/main/assets/colors/base16-3024-light-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-3024.light.256.xresources
+# Base16 3024
+# Scheme: Jan T. Sott (http://github.com/idleberg)
+foreground=#4a4543
+background=#f7f7f7
+cursorColor=#4a4543
+
+color0=#090300
+color1=#db2d20
+color2=#01a252
+color3=#fded02
+color4=#01a0e4
+color5=#a16a94
+color6=#b5e4f4
+color7=#a5a2a2
+color8=#5c5855
+color9=#db2d20
+color10=#01a252
+color11=#fded02
+color12=#01a0e4
+color13=#a16a94
+color14=#b5e4f4
+color15=#f7f7f7
+
+color16=#e8bbd0
+color17=#cdab53
+color18=#3a3432
+color19=#4a4543
+color20=#807d7c
+color21=#d6d5d4

--- a/app/src/main/assets/colors/base16-apathy-light-256.properties
+++ b/app/src/main/assets/colors/base16-apathy-light-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-apathy.light.256.xresources
+# Base16 Apathy
+# Scheme: Jannik Siebert (https://github.com/janniks)
+foreground=#184E45
+background=#D2E7E4
+cursorColor=#184E45
+
+color0=#031A16
+color1=#3E9688
+color2=#883E96
+color3=#3E4C96
+color4=#96883E
+color5=#4C963E
+color6=#963E4C
+color7=#81B5AC
+color8=#2B685E
+color9=#3E9688
+color10=#883E96
+color11=#3E4C96
+color12=#96883E
+color13=#4C963E
+color14=#963E4C
+color15=#D2E7E4
+
+color16=#3E7996
+color17=#3E965B
+color18=#0B342D
+color19=#184E45
+color20=#5F9C92
+color21=#A7CEC8

--- a/app/src/main/assets/colors/base16-ashes-dark-256.properties
+++ b/app/src/main/assets/colors/base16-ashes-dark-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-ashes.dark.256.xresources
+# Base16 Ashes
+# Scheme: Jannik Siebert (https://github.com/janniks)
+foreground=#C7CCD1
+background=#1C2023
+cursorColor=#C7CCD1
+
+color0=#1C2023
+color1=#C7AE95
+color2=#95C7AE
+color3=#AEC795
+color4=#AE95C7
+color5=#C795AE
+color6=#95AEC7
+color7=#C7CCD1
+color8=#747C84
+color9=#C7AE95
+color10=#95C7AE
+color11=#AEC795
+color12=#AE95C7
+color13=#C795AE
+color14=#95AEC7
+color15=#F3F4F5
+
+color16=#C7C795
+color17=#C79595
+color18=#393F45
+color19=#565E65
+color20=#ADB3BA
+color21=#DFE2E5

--- a/app/src/main/assets/colors/base16-ashes-light-256.properties
+++ b/app/src/main/assets/colors/base16-ashes-light-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-ashes.light.256.xresources
+# Base16 Ashes
+# Scheme: Jannik Siebert (https://github.com/janniks)
+foreground=#565E65
+background=#F3F4F5
+cursorColor=#565E65
+
+color0=#1C2023
+color1=#C7AE95
+color2=#95C7AE
+color3=#AEC795
+color4=#AE95C7
+color5=#C795AE
+color6=#95AEC7
+color7=#C7CCD1
+color8=#747C84
+color9=#C7AE95
+color10=#95C7AE
+color11=#AEC795
+color12=#AE95C7
+color13=#C795AE
+color14=#95AEC7
+color15=#F3F4F5
+
+color16=#C7C795
+color17=#C79595
+color18=#393F45
+color19=#565E65
+color20=#ADB3BA
+color21=#DFE2E5

--- a/app/src/main/assets/colors/base16-atelierdune-dark-256.properties
+++ b/app/src/main/assets/colors/base16-atelierdune-dark-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-atelierdune.dark.256.xresources
+# Base16 Atelier Dune
+# Scheme: Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/dune)
+foreground=#a6a28c
+background=#20201d
+cursorColor=#a6a28c
+
+color0=#20201d
+color1=#d73737
+color2=#60ac39
+color3=#cfb017
+color4=#6684e1
+color5=#b854d4
+color6=#1fad83
+color7=#a6a28c
+color8=#7d7a68
+color9=#d73737
+color10=#60ac39
+color11=#cfb017
+color12=#6684e1
+color13=#b854d4
+color14=#1fad83
+color15=#fefbec
+
+color16=#b65611
+color17=#d43552
+color18=#292824
+color19=#6e6b5e
+color20=#999580
+color21=#e8e4cf

--- a/app/src/main/assets/colors/base16-atelierdune-light-256.properties
+++ b/app/src/main/assets/colors/base16-atelierdune-light-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-atelierdune.light.256.xresources
+# Base16 Atelier Dune
+# Scheme: Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/dune)
+foreground=#6e6b5e
+background=#fefbec
+cursorColor=#6e6b5e
+
+color0=#20201d
+color1=#d73737
+color2=#60ac39
+color3=#cfb017
+color4=#6684e1
+color5=#b854d4
+color6=#1fad83
+color7=#a6a28c
+color8=#7d7a68
+color9=#d73737
+color10=#60ac39
+color11=#cfb017
+color12=#6684e1
+color13=#b854d4
+color14=#1fad83
+color15=#fefbec
+
+color16=#b65611
+color17=#d43552
+color18=#292824
+color19=#6e6b5e
+color20=#999580
+color21=#e8e4cf

--- a/app/src/main/assets/colors/base16-atelierforest-dark-256.properties
+++ b/app/src/main/assets/colors/base16-atelierforest-dark-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-atelierforest.dark.256.xresources
+# Base16 Atelier Forest
+# Scheme: Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/forest)
+foreground=#a8a19f
+background=#1b1918
+cursorColor=#a8a19f
+
+color0=#1b1918
+color1=#f22c40
+color2=#5ab738
+color3=#d5911a
+color4=#407ee7
+color5=#6666ea
+color6=#00ad9c
+color7=#a8a19f
+color8=#766e6b
+color9=#f22c40
+color10=#5ab738
+color11=#d5911a
+color12=#407ee7
+color13=#6666ea
+color14=#00ad9c
+color15=#f1efee
+
+color16=#df5320
+color17=#c33ff3
+color18=#2c2421
+color19=#68615e
+color20=#9c9491
+color21=#e6e2e0

--- a/app/src/main/assets/colors/base16-atelierforest-light-256.properties
+++ b/app/src/main/assets/colors/base16-atelierforest-light-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-atelierforest.light.256.xresources
+# Base16 Atelier Forest
+# Scheme: Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/forest)
+foreground=#68615e
+background=#f1efee
+cursorColor=#68615e
+
+color0=#1b1918
+color1=#f22c40
+color2=#5ab738
+color3=#d5911a
+color4=#407ee7
+color5=#6666ea
+color6=#00ad9c
+color7=#a8a19f
+color8=#766e6b
+color9=#f22c40
+color10=#5ab738
+color11=#d5911a
+color12=#407ee7
+color13=#6666ea
+color14=#00ad9c
+color15=#f1efee
+
+color16=#df5320
+color17=#c33ff3
+color18=#2c2421
+color19=#68615e
+color20=#9c9491
+color21=#e6e2e0

--- a/app/src/main/assets/colors/base16-atelierheath-dark-256.properties
+++ b/app/src/main/assets/colors/base16-atelierheath-dark-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-atelierheath.dark.256.xresources
+# Base16 Atelier Heath
+# Scheme: Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/heath)
+foreground=#ab9bab
+background=#1b181b
+cursorColor=#ab9bab
+
+color0=#1b181b
+color1=#ca402b
+color2=#379a37
+color3=#bb8a35
+color4=#516aec
+color5=#7b59c0
+color6=#159393
+color7=#ab9bab
+color8=#776977
+color9=#ca402b
+color10=#379a37
+color11=#bb8a35
+color12=#516aec
+color13=#7b59c0
+color14=#159393
+color15=#f7f3f7
+
+color16=#a65926
+color17=#cc33cc
+color18=#292329
+color19=#695d69
+color20=#9e8f9e
+color21=#d8cad8

--- a/app/src/main/assets/colors/base16-atelierheath-light-256.properties
+++ b/app/src/main/assets/colors/base16-atelierheath-light-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-atelierheath.light.256.xresources
+# Base16 Atelier Heath
+# Scheme: Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/heath)
+foreground=#695d69
+background=#f7f3f7
+cursorColor=#695d69
+
+color0=#1b181b
+color1=#ca402b
+color2=#379a37
+color3=#bb8a35
+color4=#516aec
+color5=#7b59c0
+color6=#159393
+color7=#ab9bab
+color8=#776977
+color9=#ca402b
+color10=#379a37
+color11=#bb8a35
+color12=#516aec
+color13=#7b59c0
+color14=#159393
+color15=#f7f3f7
+
+color16=#a65926
+color17=#cc33cc
+color18=#292329
+color19=#695d69
+color20=#9e8f9e
+color21=#d8cad8

--- a/app/src/main/assets/colors/base16-atelierlakeside-dark-256.properties
+++ b/app/src/main/assets/colors/base16-atelierlakeside-dark-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-atelierlakeside.dark.256.xresources
+# Base16 Atelier Lakeside
+# Scheme: Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/lakeside/)
+foreground=#7ea2b4
+background=#161b1d
+cursorColor=#7ea2b4
+
+color0=#161b1d
+color1=#d22d72
+color2=#568c3b
+color3=#8a8a0f
+color4=#257fad
+color5=#5d5db1
+color6=#2d8f6f
+color7=#7ea2b4
+color8=#5a7b8c
+color9=#d22d72
+color10=#568c3b
+color11=#8a8a0f
+color12=#257fad
+color13=#5d5db1
+color14=#2d8f6f
+color15=#ebf8ff
+
+color16=#935c25
+color17=#b72dd2
+color18=#1f292e
+color19=#516d7b
+color20=#7195a8
+color21=#c1e4f6

--- a/app/src/main/assets/colors/base16-atelierlakeside-light-256.properties
+++ b/app/src/main/assets/colors/base16-atelierlakeside-light-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-atelierlakeside.light.256.xresources
+# Base16 Atelier Lakeside
+# Scheme: Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/lakeside/)
+foreground=#516d7b
+background=#ebf8ff
+cursorColor=#516d7b
+
+color0=#161b1d
+color1=#d22d72
+color2=#568c3b
+color3=#8a8a0f
+color4=#257fad
+color5=#5d5db1
+color6=#2d8f6f
+color7=#7ea2b4
+color8=#5a7b8c
+color9=#d22d72
+color10=#568c3b
+color11=#8a8a0f
+color12=#257fad
+color13=#5d5db1
+color14=#2d8f6f
+color15=#ebf8ff
+
+color16=#935c25
+color17=#b72dd2
+color18=#1f292e
+color19=#516d7b
+color20=#7195a8
+color21=#c1e4f6

--- a/app/src/main/assets/colors/base16-atelierseaside-dark-256.properties
+++ b/app/src/main/assets/colors/base16-atelierseaside-dark-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-atelierseaside.dark.256.xresources
+# Base16 Atelier Seaside
+# Scheme: Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/seaside/)
+foreground=#8ca68c
+background=#131513
+cursorColor=#8ca68c
+
+color0=#131513
+color1=#e6193c
+color2=#29a329
+color3=#c3c322
+color4=#3d62f5
+color5=#ad2bee
+color6=#1999b3
+color7=#8ca68c
+color8=#687d68
+color9=#e6193c
+color10=#29a329
+color11=#c3c322
+color12=#3d62f5
+color13=#ad2bee
+color14=#1999b3
+color15=#f0fff0
+
+color16=#87711d
+color17=#e619c3
+color18=#242924
+color19=#5e6e5e
+color20=#809980
+color21=#cfe8cf

--- a/app/src/main/assets/colors/base16-atelierseaside-light-256.properties
+++ b/app/src/main/assets/colors/base16-atelierseaside-light-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-atelierseaside.light.256.xresources
+# Base16 Atelier Seaside
+# Scheme: Bram de Haan (http://atelierbram.github.io/syntax-highlighting/atelier-schemes/seaside/)
+foreground=#5e6e5e
+background=#f0fff0
+cursorColor=#5e6e5e
+
+color0=#131513
+color1=#e6193c
+color2=#29a329
+color3=#c3c322
+color4=#3d62f5
+color5=#ad2bee
+color6=#1999b3
+color7=#8ca68c
+color8=#687d68
+color9=#e6193c
+color10=#29a329
+color11=#c3c322
+color12=#3d62f5
+color13=#ad2bee
+color14=#1999b3
+color15=#f0fff0
+
+color16=#87711d
+color17=#e619c3
+color18=#242924
+color19=#5e6e5e
+color20=#809980
+color21=#cfe8cf

--- a/app/src/main/assets/colors/base16-bespin-dark-256.properties
+++ b/app/src/main/assets/colors/base16-bespin-dark-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-bespin.dark.256.xresources
+# Base16 Bespin
+# Scheme: Jan T. Sott
+foreground=#8a8986
+background=#28211c
+cursorColor=#8a8986
+
+color0=#28211c
+color1=#cf6a4c
+color2=#54be0d
+color3=#f9ee98
+color4=#5ea6ea
+color5=#9b859d
+color6=#afc4db
+color7=#8a8986
+color8=#666666
+color9=#cf6a4c
+color10=#54be0d
+color11=#f9ee98
+color12=#5ea6ea
+color13=#9b859d
+color14=#afc4db
+color15=#baae9e
+
+color16=#cf7d34
+color17=#937121
+color18=#36312e
+color19=#5e5d5c
+color20=#797977
+color21=#9d9b97

--- a/app/src/main/assets/colors/base16-bespin-light-256.properties
+++ b/app/src/main/assets/colors/base16-bespin-light-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-bespin.light.256.xresources
+# Base16 Bespin
+# Scheme: Jan T. Sott
+foreground=#5e5d5c
+background=#baae9e
+cursorColor=#5e5d5c
+
+color0=#28211c
+color1=#cf6a4c
+color2=#54be0d
+color3=#f9ee98
+color4=#5ea6ea
+color5=#9b859d
+color6=#afc4db
+color7=#8a8986
+color8=#666666
+color9=#cf6a4c
+color10=#54be0d
+color11=#f9ee98
+color12=#5ea6ea
+color13=#9b859d
+color14=#afc4db
+color15=#baae9e
+
+color16=#cf7d34
+color17=#937121
+color18=#36312e
+color19=#5e5d5c
+color20=#797977
+color21=#9d9b97

--- a/app/src/main/assets/colors/base16-brewer-dark-256.properties
+++ b/app/src/main/assets/colors/base16-brewer-dark-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-brewer.dark.256.xresources
+# Base16 Brewer
+# Scheme: Timothée Poisot (http://github.com/tpoisot)
+foreground=#b7b8b9
+background=#0c0d0e
+cursorColor=#b7b8b9
+
+color0=#0c0d0e
+color1=#e31a1c
+color2=#31a354
+color3=#dca060
+color4=#3182bd
+color5=#756bb1
+color6=#80b1d3
+color7=#b7b8b9
+color8=#737475
+color9=#e31a1c
+color10=#31a354
+color11=#dca060
+color12=#3182bd
+color13=#756bb1
+color14=#80b1d3
+color15=#fcfdfe
+
+color16=#e6550d
+color17=#b15928
+color18=#2e2f30
+color19=#515253
+color20=#959697
+color21=#dadbdc

--- a/app/src/main/assets/colors/base16-brewer-light-256.properties
+++ b/app/src/main/assets/colors/base16-brewer-light-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-brewer.light.256.xresources
+# Base16 Brewer
+# Scheme: Timothée Poisot (http://github.com/tpoisot)
+foreground=#515253
+background=#fcfdfe
+cursorColor=#515253
+
+color0=#0c0d0e
+color1=#e31a1c
+color2=#31a354
+color3=#dca060
+color4=#3182bd
+color5=#756bb1
+color6=#80b1d3
+color7=#b7b8b9
+color8=#737475
+color9=#e31a1c
+color10=#31a354
+color11=#dca060
+color12=#3182bd
+color13=#756bb1
+color14=#80b1d3
+color15=#fcfdfe
+
+color16=#e6550d
+color17=#b15928
+color18=#2e2f30
+color19=#515253
+color20=#959697
+color21=#dadbdc

--- a/app/src/main/assets/colors/base16-bright-dark-256.properties
+++ b/app/src/main/assets/colors/base16-bright-dark-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-bright.dark.256.xresources
+# Base16 Bright
+# Scheme: Chris Kempson (http://chriskempson.com)
+foreground=#e0e0e0
+background=#000000
+cursorColor=#e0e0e0
+
+color0=#000000
+color1=#fb0120
+color2=#a1c659
+color3=#fda331
+color4=#6fb3d2
+color5=#d381c3
+color6=#76c7b7
+color7=#e0e0e0
+color8=#b0b0b0
+color9=#fb0120
+color10=#a1c659
+color11=#fda331
+color12=#6fb3d2
+color13=#d381c3
+color14=#76c7b7
+color15=#ffffff
+
+color16=#fc6d24
+color17=#be643c
+color18=#303030
+color19=#505050
+color20=#d0d0d0
+color21=#f5f5f5

--- a/app/src/main/assets/colors/base16-bright-light-256.properties
+++ b/app/src/main/assets/colors/base16-bright-light-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-bright.light.256.xresources
+# Base16 Bright
+# Scheme: Chris Kempson (http://chriskempson.com)
+foreground=#505050
+background=#ffffff
+cursorColor=#505050
+
+color0=#000000
+color1=#fb0120
+color2=#a1c659
+color3=#fda331
+color4=#6fb3d2
+color5=#d381c3
+color6=#76c7b7
+color7=#e0e0e0
+color8=#b0b0b0
+color9=#fb0120
+color10=#a1c659
+color11=#fda331
+color12=#6fb3d2
+color13=#d381c3
+color14=#76c7b7
+color15=#ffffff
+
+color16=#fc6d24
+color17=#be643c
+color18=#303030
+color19=#505050
+color20=#d0d0d0
+color21=#f5f5f5

--- a/app/src/main/assets/colors/base16-chalk-dark-256.properties
+++ b/app/src/main/assets/colors/base16-chalk-dark-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-chalk.dark.256.xresources
+# Base16 Chalk
+# Scheme: Chris Kempson (http://chriskempson.com)
+foreground=#d0d0d0
+background=#151515
+cursorColor=#d0d0d0
+
+color0=#151515
+color1=#fb9fb1
+color2=#acc267
+color3=#ddb26f
+color4=#6fc2ef
+color5=#e1a3ee
+color6=#12cfc0
+color7=#d0d0d0
+color8=#505050
+color9=#fb9fb1
+color10=#acc267
+color11=#ddb26f
+color12=#6fc2ef
+color13=#e1a3ee
+color14=#12cfc0
+color15=#f5f5f5
+
+color16=#eda987
+color17=#deaf8f
+color18=#202020
+color19=#303030
+color20=#b0b0b0
+color21=#e0e0e0

--- a/app/src/main/assets/colors/base16-chalk-light-256.properties
+++ b/app/src/main/assets/colors/base16-chalk-light-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-chalk.light.256.xresources
+# Base16 Chalk
+# Scheme: Chris Kempson (http://chriskempson.com)
+foreground=#303030
+background=#f5f5f5
+cursorColor=#303030
+
+color0=#151515
+color1=#fb9fb1
+color2=#acc267
+color3=#ddb26f
+color4=#6fc2ef
+color5=#e1a3ee
+color6=#12cfc0
+color7=#d0d0d0
+color8=#505050
+color9=#fb9fb1
+color10=#acc267
+color11=#ddb26f
+color12=#6fc2ef
+color13=#e1a3ee
+color14=#12cfc0
+color15=#f5f5f5
+
+color16=#eda987
+color17=#deaf8f
+color18=#202020
+color19=#303030
+color20=#b0b0b0
+color21=#e0e0e0

--- a/app/src/main/assets/colors/base16-codeschool-dark-256.properties
+++ b/app/src/main/assets/colors/base16-codeschool-dark-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-codeschool.dark.256.xresources
+# Base16 Codeschool
+# Scheme: brettof86
+foreground=#9ea7a6
+background=#232c31
+cursorColor=#9ea7a6
+
+color0=#232c31
+color1=#2a5491
+color2=#237986
+color3=#a03b1e
+color4=#484d79
+color5=#c59820
+color6=#b02f30
+color7=#9ea7a6
+color8=#3f4944
+color9=#2a5491
+color10=#237986
+color11=#a03b1e
+color12=#484d79
+color13=#c59820
+color14=#b02f30
+color15=#b5d8f6
+
+color16=#43820d
+color17=#c98344
+color18=#1c3657
+color19=#2a343a
+color20=#84898c
+color21=#a7cfa3

--- a/app/src/main/assets/colors/base16-codeschool-light-256.properties
+++ b/app/src/main/assets/colors/base16-codeschool-light-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-codeschool.light.256.xresources
+# Base16 Codeschool
+# Scheme: brettof86
+foreground=#2a343a
+background=#b5d8f6
+cursorColor=#2a343a
+
+color0=#232c31
+color1=#2a5491
+color2=#237986
+color3=#a03b1e
+color4=#484d79
+color5=#c59820
+color6=#b02f30
+color7=#9ea7a6
+color8=#3f4944
+color9=#2a5491
+color10=#237986
+color11=#a03b1e
+color12=#484d79
+color13=#c59820
+color14=#b02f30
+color15=#b5d8f6
+
+color16=#43820d
+color17=#c98344
+color18=#1c3657
+color19=#2a343a
+color20=#84898c
+color21=#a7cfa3

--- a/app/src/main/assets/colors/base16-colors-dark-256.properties
+++ b/app/src/main/assets/colors/base16-colors-dark-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-colors.dark.256.xresources
+# Base16 Colors
+# Scheme: mrmrs (http://clrs.cc)
+foreground=#bbbbbb
+background=#111111
+cursorColor=#bbbbbb
+
+color0=#111111
+color1=#ff4136
+color2=#2ecc40
+color3=#ffdc00
+color4=#0074d9
+color5=#b10dc9
+color6=#7fdbff
+color7=#bbbbbb
+color8=#777777
+color9=#ff4136
+color10=#2ecc40
+color11=#ffdc00
+color12=#0074d9
+color13=#b10dc9
+color14=#7fdbff
+color15=#ffffff
+
+color16=#ff851b
+color17=#85144b
+color18=#333333
+color19=#555555
+color20=#999999
+color21=#dddddd

--- a/app/src/main/assets/colors/base16-colors-light-256.properties
+++ b/app/src/main/assets/colors/base16-colors-light-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-colors.light.256.xresources
+# Base16 Colors
+# Scheme: mrmrs (http://clrs.cc)
+foreground=#555555
+background=#ffffff
+cursorColor=#555555
+
+color0=#111111
+color1=#ff4136
+color2=#2ecc40
+color3=#ffdc00
+color4=#0074d9
+color5=#b10dc9
+color6=#7fdbff
+color7=#bbbbbb
+color8=#777777
+color9=#ff4136
+color10=#2ecc40
+color11=#ffdc00
+color12=#0074d9
+color13=#b10dc9
+color14=#7fdbff
+color15=#ffffff
+
+color16=#ff851b
+color17=#85144b
+color18=#333333
+color19=#555555
+color20=#999999
+color21=#dddddd

--- a/app/src/main/assets/colors/base16-eighties-dark-256.properties
+++ b/app/src/main/assets/colors/base16-eighties-dark-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-eighties.dark.256.xresources
+# Base16 Eighties
+# Scheme: Chris Kempson (http://chriskempson.com)
+foreground=#d3d0c8
+background=#2d2d2d
+cursorColor=#d3d0c8
+
+color0=#2d2d2d
+color1=#f2777a
+color2=#99cc99
+color3=#ffcc66
+color4=#6699cc
+color5=#cc99cc
+color6=#66cccc
+color7=#d3d0c8
+color8=#747369
+color9=#f2777a
+color10=#99cc99
+color11=#ffcc66
+color12=#6699cc
+color13=#cc99cc
+color14=#66cccc
+color15=#f2f0ec
+
+color16=#f99157
+color17=#d27b53
+color18=#393939
+color19=#515151
+color20=#a09f93
+color21=#e8e6df

--- a/app/src/main/assets/colors/base16-eighties-light-256.properties
+++ b/app/src/main/assets/colors/base16-eighties-light-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-eighties.light.256.xresources
+# Base16 Eighties
+# Scheme: Chris Kempson (http://chriskempson.com)
+foreground=#515151
+background=#f2f0ec
+cursorColor=#515151
+
+color0=#2d2d2d
+color1=#f2777a
+color2=#99cc99
+color3=#ffcc66
+color4=#6699cc
+color5=#cc99cc
+color6=#66cccc
+color7=#d3d0c8
+color8=#747369
+color9=#f2777a
+color10=#99cc99
+color11=#ffcc66
+color12=#6699cc
+color13=#cc99cc
+color14=#66cccc
+color15=#f2f0ec
+
+color16=#f99157
+color17=#d27b53
+color18=#393939
+color19=#515151
+color20=#a09f93
+color21=#e8e6df

--- a/app/src/main/assets/colors/base16-embers-dark-256.properties
+++ b/app/src/main/assets/colors/base16-embers-dark-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-embers.dark.256.xresources
+# Base16 Embers
+# Scheme: Jannik Siebert (https://github.com/janniks)
+foreground=#A39A90
+background=#16130F
+cursorColor=#A39A90
+
+color0=#16130F
+color1=#826D57
+color2=#57826D
+color3=#6D8257
+color4=#6D5782
+color5=#82576D
+color6=#576D82
+color7=#A39A90
+color8=#5A5047
+color9=#826D57
+color10=#57826D
+color11=#6D8257
+color12=#6D5782
+color13=#82576D
+color14=#576D82
+color15=#DBD6D1
+
+color16=#828257
+color17=#825757
+color18=#2C2620
+color19=#433B32
+color20=#8A8075
+color21=#BEB6AE

--- a/app/src/main/assets/colors/base16-embers-light-256.properties
+++ b/app/src/main/assets/colors/base16-embers-light-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-embers.light.256.xresources
+# Base16 Embers
+# Scheme: Jannik Siebert (https://github.com/janniks)
+foreground=#433B32
+background=#DBD6D1
+cursorColor=#433B32
+
+color0=#16130F
+color1=#826D57
+color2=#57826D
+color3=#6D8257
+color4=#6D5782
+color5=#82576D
+color6=#576D82
+color7=#A39A90
+color8=#5A5047
+color9=#826D57
+color10=#57826D
+color11=#6D8257
+color12=#6D5782
+color13=#82576D
+color14=#576D82
+color15=#DBD6D1
+
+color16=#828257
+color17=#825757
+color18=#2C2620
+color19=#433B32
+color20=#8A8075
+color21=#BEB6AE

--- a/app/src/main/assets/colors/base16-flat-dark-256.properties
+++ b/app/src/main/assets/colors/base16-flat-dark-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-flat.dark.256.xresources
+# Base16 Flat
+# Scheme: Chris Kempson (http://chriskempson.com)
+foreground=#e0e0e0
+background=#2C3E50
+cursorColor=#e0e0e0
+
+color0=#2C3E50
+color1=#E74C3C
+color2=#2ECC71
+color3=#F1C40F
+color4=#3498DB
+color5=#9B59B6
+color6=#1ABC9C
+color7=#e0e0e0
+color8=#95A5A6
+color9=#E74C3C
+color10=#2ECC71
+color11=#F1C40F
+color12=#3498DB
+color13=#9B59B6
+color14=#1ABC9C
+color15=#ECF0F1
+
+color16=#E67E22
+color17=#be643c
+color18=#34495E
+color19=#7F8C8D
+color20=#BDC3C7
+color21=#f5f5f5

--- a/app/src/main/assets/colors/base16-flat-light-256.properties
+++ b/app/src/main/assets/colors/base16-flat-light-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-flat.light.256.xresources
+# Base16 Flat
+# Scheme: Chris Kempson (http://chriskempson.com)
+foreground=#7F8C8D
+background=#ECF0F1
+cursorColor=#7F8C8D
+
+color0=#2C3E50
+color1=#E74C3C
+color2=#2ECC71
+color3=#F1C40F
+color4=#3498DB
+color5=#9B59B6
+color6=#1ABC9C
+color7=#e0e0e0
+color8=#95A5A6
+color9=#E74C3C
+color10=#2ECC71
+color11=#F1C40F
+color12=#3498DB
+color13=#9B59B6
+color14=#1ABC9C
+color15=#ECF0F1
+
+color16=#E67E22
+color17=#be643c
+color18=#34495E
+color19=#7F8C8D
+color20=#BDC3C7
+color21=#f5f5f5

--- a/app/src/main/assets/colors/base16-google-dark-256.properties
+++ b/app/src/main/assets/colors/base16-google-dark-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-google.dark.256.xresources
+# Base16 Google
+# Scheme: Seth Wright (http://sethawright.com)
+foreground=#c5c8c6
+background=#1d1f21
+cursorColor=#c5c8c6
+
+color0=#1d1f21
+color1=#CC342B
+color2=#198844
+color3=#FBA922
+color4=#3971ED
+color5=#A36AC7
+color6=#3971ED
+color7=#c5c8c6
+color8=#969896
+color9=#CC342B
+color10=#198844
+color11=#FBA922
+color12=#3971ED
+color13=#A36AC7
+color14=#3971ED
+color15=#ffffff
+
+color16=#F96A38
+color17=#3971ED
+color18=#282a2e
+color19=#373b41
+color20=#b4b7b4
+color21=#e0e0e0

--- a/app/src/main/assets/colors/base16-google-light-256.properties
+++ b/app/src/main/assets/colors/base16-google-light-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-google.light.256.xresources
+# Base16 Google
+# Scheme: Seth Wright (http://sethawright.com)
+foreground=#373b41
+background=#ffffff
+cursorColor=#373b41
+
+color0=#1d1f21
+color1=#CC342B
+color2=#198844
+color3=#FBA922
+color4=#3971ED
+color5=#A36AC7
+color6=#3971ED
+color7=#c5c8c6
+color8=#969896
+color9=#CC342B
+color10=#198844
+color11=#FBA922
+color12=#3971ED
+color13=#A36AC7
+color14=#3971ED
+color15=#ffffff
+
+color16=#F96A38
+color17=#3971ED
+color18=#282a2e
+color19=#373b41
+color20=#b4b7b4
+color21=#e0e0e0

--- a/app/src/main/assets/colors/base16-grayscale-dark-256.properties
+++ b/app/src/main/assets/colors/base16-grayscale-dark-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-grayscale.dark.256.xresources
+# Base16 Grayscale
+# Scheme: Alexandre Gavioli (https://github.com/Alexx2/)
+foreground=#b9b9b9
+background=#101010
+cursorColor=#b9b9b9
+
+color0=#101010
+color1=#7c7c7c
+color2=#8e8e8e
+color3=#a0a0a0
+color4=#686868
+color5=#747474
+color6=#868686
+color7=#b9b9b9
+color8=#525252
+color9=#7c7c7c
+color10=#8e8e8e
+color11=#a0a0a0
+color12=#686868
+color13=#747474
+color14=#868686
+color15=#f7f7f7
+
+color16=#999999
+color17=#5e5e5e
+color18=#252525
+color19=#464646
+color20=#ababab
+color21=#e3e3e3

--- a/app/src/main/assets/colors/base16-grayscale-light-256.properties
+++ b/app/src/main/assets/colors/base16-grayscale-light-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-grayscale.light.256.xresources
+# Base16 Grayscale
+# Scheme: Alexandre Gavioli (https://github.com/Alexx2/)
+foreground=#464646
+background=#f7f7f7
+cursorColor=#464646
+
+color0=#101010
+color1=#7c7c7c
+color2=#8e8e8e
+color3=#a0a0a0
+color4=#686868
+color5=#747474
+color6=#868686
+color7=#b9b9b9
+color8=#525252
+color9=#7c7c7c
+color10=#8e8e8e
+color11=#a0a0a0
+color12=#686868
+color13=#747474
+color14=#868686
+color15=#f7f7f7
+
+color16=#999999
+color17=#5e5e5e
+color18=#252525
+color19=#464646
+color20=#ababab
+color21=#e3e3e3

--- a/app/src/main/assets/colors/base16-greenscreen-light-256.properties
+++ b/app/src/main/assets/colors/base16-greenscreen-light-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-greenscreen.light.256.xresources
+# Base16 Green Screen
+# Scheme: Chris Kempson (http://chriskempson.com)
+foreground=#005500
+background=#00ff00
+cursorColor=#005500
+
+color0=#001100
+color1=#007700
+color2=#00bb00
+color3=#007700
+color4=#009900
+color5=#00bb00
+color6=#005500
+color7=#00bb00
+color8=#007700
+color9=#007700
+color10=#00bb00
+color11=#007700
+color12=#009900
+color13=#00bb00
+color14=#005500
+color15=#00ff00
+
+color16=#009900
+color17=#005500
+color18=#003300
+color19=#005500
+color20=#009900
+color21=#00dd00

--- a/app/src/main/assets/colors/base16-harmonic16-dark-256.properties
+++ b/app/src/main/assets/colors/base16-harmonic16-dark-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-harmonic16.dark.256.xresources
+# Base16 harmonic16
+# Scheme: Jannik Siebert (https://github.com/janniks)
+foreground=#cbd6e2
+background=#0b1c2c
+cursorColor=#cbd6e2
+
+color0=#0b1c2c
+color1=#bf8b56
+color2=#56bf8b
+color3=#8bbf56
+color4=#8b56bf
+color5=#bf568b
+color6=#568bbf
+color7=#cbd6e2
+color8=#627e99
+color9=#bf8b56
+color10=#56bf8b
+color11=#8bbf56
+color12=#8b56bf
+color13=#bf568b
+color14=#568bbf
+color15=#f7f9fb
+
+color16=#bfbf56
+color17=#bf5656
+color18=#223b54
+color19=#405c79
+color20=#aabcce
+color21=#e5ebf1

--- a/app/src/main/assets/colors/base16-harmonic16-light-256.properties
+++ b/app/src/main/assets/colors/base16-harmonic16-light-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-harmonic16.light.256.xresources
+# Base16 harmonic16
+# Scheme: Jannik Siebert (https://github.com/janniks)
+foreground=#405c79
+background=#f7f9fb
+cursorColor=#405c79
+
+color0=#0b1c2c
+color1=#bf8b56
+color2=#56bf8b
+color3=#8bbf56
+color4=#8b56bf
+color5=#bf568b
+color6=#568bbf
+color7=#cbd6e2
+color8=#627e99
+color9=#bf8b56
+color10=#56bf8b
+color11=#8bbf56
+color12=#8b56bf
+color13=#bf568b
+color14=#568bbf
+color15=#f7f9fb
+
+color16=#bfbf56
+color17=#bf5656
+color18=#223b54
+color19=#405c79
+color20=#aabcce
+color21=#e5ebf1

--- a/app/src/main/assets/colors/base16-isotope-light-256.properties
+++ b/app/src/main/assets/colors/base16-isotope-light-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-isotope.light.256.xresources
+# Base16 Isotope
+# Scheme: Jan T. Sott
+foreground=#606060
+background=#ffffff
+cursorColor=#606060
+
+color0=#000000
+color1=#ff0000
+color2=#33ff00
+color3=#ff0099
+color4=#0066ff
+color5=#cc00ff
+color6=#00ffff
+color7=#d0d0d0
+color8=#808080
+color9=#ff0000
+color10=#33ff00
+color11=#ff0099
+color12=#0066ff
+color13=#cc00ff
+color14=#00ffff
+color15=#ffffff
+
+color16=#ff9900
+color17=#3300ff
+color18=#404040
+color19=#606060
+color20=#c0c0c0
+color21=#e0e0e0

--- a/app/src/main/assets/colors/base16-londontube-dark-256.properties
+++ b/app/src/main/assets/colors/base16-londontube-dark-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-londontube.dark.256.xresources
+# Base16 London Tube
+# Scheme: Jan T. Sott
+foreground=#d9d8d8
+background=#231f20
+cursorColor=#d9d8d8
+
+color0=#231f20
+color1=#ee2e24
+color2=#00853e
+color3=#ffd204
+color4=#009ddc
+color5=#98005d
+color6=#85cebc
+color7=#d9d8d8
+color8=#737171
+color9=#ee2e24
+color10=#00853e
+color11=#ffd204
+color12=#009ddc
+color13=#98005d
+color14=#85cebc
+color15=#ffffff
+
+color16=#f386a1
+color17=#b06110
+color18=#1c3f95
+color19=#5a5758
+color20=#959ca1
+color21=#e7e7e8

--- a/app/src/main/assets/colors/base16-londontube-light-256.properties
+++ b/app/src/main/assets/colors/base16-londontube-light-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-londontube.light.256.xresources
+# Base16 London Tube
+# Scheme: Jan T. Sott
+foreground=#5a5758
+background=#ffffff
+cursorColor=#5a5758
+
+color0=#231f20
+color1=#ee2e24
+color2=#00853e
+color3=#ffd204
+color4=#009ddc
+color5=#98005d
+color6=#85cebc
+color7=#d9d8d8
+color8=#737171
+color9=#ee2e24
+color10=#00853e
+color11=#ffd204
+color12=#009ddc
+color13=#98005d
+color14=#85cebc
+color15=#ffffff
+
+color16=#f386a1
+color17=#b06110
+color18=#1c3f95
+color19=#5a5758
+color20=#959ca1
+color21=#e7e7e8

--- a/app/src/main/assets/colors/base16-marrakesh-dark-256.properties
+++ b/app/src/main/assets/colors/base16-marrakesh-dark-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-marrakesh.dark.256.xresources
+# Base16 Marrakesh
+# Scheme: Alexandre Gavioli (http://github.com/Alexx2/)
+foreground=#948e48
+background=#201602
+cursorColor=#948e48
+
+color0=#201602
+color1=#c35359
+color2=#18974e
+color3=#a88339
+color4=#477ca1
+color5=#8868b3
+color6=#75a738
+color7=#948e48
+color8=#6c6823
+color9=#c35359
+color10=#18974e
+color11=#a88339
+color12=#477ca1
+color13=#8868b3
+color14=#75a738
+color15=#faf0a5
+
+color16=#b36144
+color17=#b3588e
+color18=#302e00
+color19=#5f5b17
+color20=#86813b
+color21=#ccc37a

--- a/app/src/main/assets/colors/base16-marrakesh-light-256.properties
+++ b/app/src/main/assets/colors/base16-marrakesh-light-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-marrakesh.light.256.xresources
+# Base16 Marrakesh
+# Scheme: Alexandre Gavioli (http://github.com/Alexx2/)
+foreground=#5f5b17
+background=#faf0a5
+cursorColor=#5f5b17
+
+color0=#201602
+color1=#c35359
+color2=#18974e
+color3=#a88339
+color4=#477ca1
+color5=#8868b3
+color6=#75a738
+color7=#948e48
+color8=#6c6823
+color9=#c35359
+color10=#18974e
+color11=#a88339
+color12=#477ca1
+color13=#8868b3
+color14=#75a738
+color15=#faf0a5
+
+color16=#b36144
+color17=#b3588e
+color18=#302e00
+color19=#5f5b17
+color20=#86813b
+color21=#ccc37a

--- a/app/src/main/assets/colors/base16-mocha-dark-256.properties
+++ b/app/src/main/assets/colors/base16-mocha-dark-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-mocha.dark.256.xresources
+# Base16 Mocha
+# Scheme: Chris Kempson (http://chriskempson.com)
+foreground=#d0c8c6
+background=#3B3228
+cursorColor=#d0c8c6
+
+color0=#3B3228
+color1=#cb6077
+color2=#beb55b
+color3=#f4bc87
+color4=#8ab3b5
+color5=#a89bb9
+color6=#7bbda4
+color7=#d0c8c6
+color8=#7e705a
+color9=#cb6077
+color10=#beb55b
+color11=#f4bc87
+color12=#8ab3b5
+color13=#a89bb9
+color14=#7bbda4
+color15=#f5eeeb
+
+color16=#d28b71
+color17=#bb9584
+color18=#534636
+color19=#645240
+color20=#b8afad
+color21=#e9e1dd

--- a/app/src/main/assets/colors/base16-mocha-light-256.properties
+++ b/app/src/main/assets/colors/base16-mocha-light-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-mocha.light.256.xresources
+# Base16 Mocha
+# Scheme: Chris Kempson (http://chriskempson.com)
+foreground=#645240
+background=#f5eeeb
+cursorColor=#645240
+
+color0=#3B3228
+color1=#cb6077
+color2=#beb55b
+color3=#f4bc87
+color4=#8ab3b5
+color5=#a89bb9
+color6=#7bbda4
+color7=#d0c8c6
+color8=#7e705a
+color9=#cb6077
+color10=#beb55b
+color11=#f4bc87
+color12=#8ab3b5
+color13=#a89bb9
+color14=#7bbda4
+color15=#f5eeeb
+
+color16=#d28b71
+color17=#bb9584
+color18=#534636
+color19=#645240
+color20=#b8afad
+color21=#e9e1dd

--- a/app/src/main/assets/colors/base16-monokai-light-256.properties
+++ b/app/src/main/assets/colors/base16-monokai-light-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-monokai.light.256.xresources
+# Base16 Monokai
+# Scheme: Wimer Hazenberg (http://www.monokai.nl)
+foreground=#49483e
+background=#f9f8f5
+cursorColor=#49483e
+
+color0=#272822
+color1=#f92672
+color2=#a6e22e
+color3=#f4bf75
+color4=#66d9ef
+color5=#ae81ff
+color6=#a1efe4
+color7=#f8f8f2
+color8=#75715e
+color9=#f92672
+color10=#a6e22e
+color11=#f4bf75
+color12=#66d9ef
+color13=#ae81ff
+color14=#a1efe4
+color15=#f9f8f5
+
+color16=#fd971f
+color17=#cc6633
+color18=#383830
+color19=#49483e
+color20=#a59f85
+color21=#f5f4f1

--- a/app/src/main/assets/colors/base16-paraiso-dark-256.properties
+++ b/app/src/main/assets/colors/base16-paraiso-dark-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-paraiso.dark.256.xresources
+# Base16 Paraiso
+# Scheme: Jan T. Sott
+foreground=#a39e9b
+background=#2f1e2e
+cursorColor=#a39e9b
+
+color0=#2f1e2e
+color1=#ef6155
+color2=#48b685
+color3=#fec418
+color4=#06b6ef
+color5=#815ba4
+color6=#5bc4bf
+color7=#a39e9b
+color8=#776e71
+color9=#ef6155
+color10=#48b685
+color11=#fec418
+color12=#06b6ef
+color13=#815ba4
+color14=#5bc4bf
+color15=#e7e9db
+
+color16=#f99b15
+color17=#e96ba8
+color18=#41323f
+color19=#4f424c
+color20=#8d8687
+color21=#b9b6b0

--- a/app/src/main/assets/colors/base16-paraiso-light-256.properties
+++ b/app/src/main/assets/colors/base16-paraiso-light-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-paraiso.light.256.xresources
+# Base16 Paraiso
+# Scheme: Jan T. Sott
+foreground=#4f424c
+background=#e7e9db
+cursorColor=#4f424c
+
+color0=#2f1e2e
+color1=#ef6155
+color2=#48b685
+color3=#fec418
+color4=#06b6ef
+color5=#815ba4
+color6=#5bc4bf
+color7=#a39e9b
+color8=#776e71
+color9=#ef6155
+color10=#48b685
+color11=#fec418
+color12=#06b6ef
+color13=#815ba4
+color14=#5bc4bf
+color15=#e7e9db
+
+color16=#f99b15
+color17=#e96ba8
+color18=#41323f
+color19=#4f424c
+color20=#8d8687
+color21=#b9b6b0

--- a/app/src/main/assets/colors/base16-railscasts-dark-256.properties
+++ b/app/src/main/assets/colors/base16-railscasts-dark-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-railscasts.dark.256.xresources
+# Base16 Railscasts
+# Scheme: Ryan Bates (http://railscasts.com)
+foreground=#e6e1dc
+background=#2b2b2b
+cursorColor=#e6e1dc
+
+color0=#2b2b2b
+color1=#da4939
+color2=#a5c261
+color3=#ffc66d
+color4=#6d9cbe
+color5=#b6b3eb
+color6=#519f50
+color7=#e6e1dc
+color8=#5a647e
+color9=#da4939
+color10=#a5c261
+color11=#ffc66d
+color12=#6d9cbe
+color13=#b6b3eb
+color14=#519f50
+color15=#f9f7f3
+
+color16=#cc7833
+color17=#bc9458
+color18=#272935
+color19=#3a4055
+color20=#d4cfc9
+color21=#f4f1ed

--- a/app/src/main/assets/colors/base16-railscasts-light-256.properties
+++ b/app/src/main/assets/colors/base16-railscasts-light-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-railscasts.light.256.xresources
+# Base16 Railscasts
+# Scheme: Ryan Bates (http://railscasts.com)
+foreground=#3a4055
+background=#f9f7f3
+cursorColor=#3a4055
+
+color0=#2b2b2b
+color1=#da4939
+color2=#a5c261
+color3=#ffc66d
+color4=#6d9cbe
+color5=#b6b3eb
+color6=#519f50
+color7=#e6e1dc
+color8=#5a647e
+color9=#da4939
+color10=#a5c261
+color11=#ffc66d
+color12=#6d9cbe
+color13=#b6b3eb
+color14=#519f50
+color15=#f9f7f3
+
+color16=#cc7833
+color17=#bc9458
+color18=#272935
+color19=#3a4055
+color20=#d4cfc9
+color21=#f4f1ed

--- a/app/src/main/assets/colors/base16-shapeshifter-dark-256.properties
+++ b/app/src/main/assets/colors/base16-shapeshifter-dark-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-shapeshifter.dark.256.xresources
+# Base16 shapeshifter
+# Scheme: Tyler Benziger (http://tybenz.com)
+foreground=#ababab
+background=#000000
+cursorColor=#ababab
+
+color0=#000000
+color1=#e92f2f
+color2=#0ed839
+color3=#dddd13
+color4=#3b48e3
+color5=#f996e2
+color6=#23edda
+color7=#ababab
+color8=#343434
+color9=#e92f2f
+color10=#0ed839
+color11=#dddd13
+color12=#3b48e3
+color13=#f996e2
+color14=#23edda
+color15=#f9f9f9
+
+color16=#e09448
+color17=#69542d
+color18=#040404
+color19=#102015
+color20=#555555
+color21=#e0e0e0

--- a/app/src/main/assets/colors/base16-shapeshifter-light-256.properties
+++ b/app/src/main/assets/colors/base16-shapeshifter-light-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-shapeshifter.light.256.xresources
+# Base16 shapeshifter
+# Scheme: Tyler Benziger (http://tybenz.com)
+foreground=#102015
+background=#f9f9f9
+cursorColor=#102015
+
+color0=#000000
+color1=#e92f2f
+color2=#0ed839
+color3=#dddd13
+color4=#3b48e3
+color5=#f996e2
+color6=#23edda
+color7=#ababab
+color8=#343434
+color9=#e92f2f
+color10=#0ed839
+color11=#dddd13
+color12=#3b48e3
+color13=#f996e2
+color14=#23edda
+color15=#f9f9f9
+
+color16=#e09448
+color17=#69542d
+color18=#040404
+color19=#102015
+color20=#555555
+color21=#e0e0e0

--- a/app/src/main/assets/colors/base16-summerfruit-dark-256.properties
+++ b/app/src/main/assets/colors/base16-summerfruit-dark-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-summerfruit.dark.256.xresources
+# Base16 Summerfruit
+# Scheme: Christopher Corley (http://cscorley.github.io/)
+foreground=#D0D0D0
+background=#151515
+cursorColor=#D0D0D0
+
+color0=#151515
+color1=#FF0086
+color2=#00C918
+color3=#ABA800
+color4=#3777E6
+color5=#AD00A1
+color6=#1faaaa
+color7=#D0D0D0
+color8=#505050
+color9=#FF0086
+color10=#00C918
+color11=#ABA800
+color12=#3777E6
+color13=#AD00A1
+color14=#1faaaa
+color15=#FFFFFF
+
+color16=#FD8900
+color17=#cc6633
+color18=#202020
+color19=#303030
+color20=#B0B0B0
+color21=#E0E0E0

--- a/app/src/main/assets/colors/base16-summerfruit-light-256.properties
+++ b/app/src/main/assets/colors/base16-summerfruit-light-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-summerfruit.light.256.xresources
+# Base16 Summerfruit
+# Scheme: Christopher Corley (http://cscorley.github.io/)
+foreground=#303030
+background=#FFFFFF
+cursorColor=#303030
+
+color0=#151515
+color1=#FF0086
+color2=#00C918
+color3=#ABA800
+color4=#3777E6
+color5=#AD00A1
+color6=#1faaaa
+color7=#D0D0D0
+color8=#505050
+color9=#FF0086
+color10=#00C918
+color11=#ABA800
+color12=#3777E6
+color13=#AD00A1
+color14=#1faaaa
+color15=#FFFFFF
+
+color16=#FD8900
+color17=#cc6633
+color18=#202020
+color19=#303030
+color20=#B0B0B0
+color21=#E0E0E0

--- a/app/src/main/assets/colors/base16-tomorrow-dark-256.properties
+++ b/app/src/main/assets/colors/base16-tomorrow-dark-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-tomorrow.dark.256.xresources
+# Base16 Tomorrow
+# Scheme: Chris Kempson (http://chriskempson.com)
+foreground=#c5c8c6
+background=#1d1f21
+cursorColor=#c5c8c6
+
+color0=#1d1f21
+color1=#cc6666
+color2=#b5bd68
+color3=#f0c674
+color4=#81a2be
+color5=#b294bb
+color6=#8abeb7
+color7=#c5c8c6
+color8=#969896
+color9=#cc6666
+color10=#b5bd68
+color11=#f0c674
+color12=#81a2be
+color13=#b294bb
+color14=#8abeb7
+color15=#ffffff
+
+color16=#de935f
+color17=#a3685a
+color18=#282a2e
+color19=#373b41
+color20=#b4b7b4
+color21=#e0e0e0

--- a/app/src/main/assets/colors/base16-tomorrow-light-256.properties
+++ b/app/src/main/assets/colors/base16-tomorrow-light-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-tomorrow.light.256.xresources
+# Base16 Tomorrow
+# Scheme: Chris Kempson (http://chriskempson.com)
+foreground=#373b41
+background=#ffffff
+cursorColor=#373b41
+
+color0=#1d1f21
+color1=#cc6666
+color2=#b5bd68
+color3=#f0c674
+color4=#81a2be
+color5=#b294bb
+color6=#8abeb7
+color7=#c5c8c6
+color8=#969896
+color9=#cc6666
+color10=#b5bd68
+color11=#f0c674
+color12=#81a2be
+color13=#b294bb
+color14=#8abeb7
+color15=#ffffff
+
+color16=#de935f
+color17=#a3685a
+color18=#282a2e
+color19=#373b41
+color20=#b4b7b4
+color21=#e0e0e0

--- a/app/src/main/assets/colors/base16-twilight-dark-256.properties
+++ b/app/src/main/assets/colors/base16-twilight-dark-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-twilight.dark.256.xresources
+# Base16 Twilight
+# Scheme: David Hart (http://hart-dev.com)
+foreground=#a7a7a7
+background=#1e1e1e
+cursorColor=#a7a7a7
+
+color0=#1e1e1e
+color1=#cf6a4c
+color2=#8f9d6a
+color3=#f9ee98
+color4=#7587a6
+color5=#9b859d
+color6=#afc4db
+color7=#a7a7a7
+color8=#5f5a60
+color9=#cf6a4c
+color10=#8f9d6a
+color11=#f9ee98
+color12=#7587a6
+color13=#9b859d
+color14=#afc4db
+color15=#ffffff
+
+color16=#cda869
+color17=#9b703f
+color18=#323537
+color19=#464b50
+color20=#838184
+color21=#c3c3c3

--- a/app/src/main/assets/colors/base16-twilight-light-256.properties
+++ b/app/src/main/assets/colors/base16-twilight-light-256.properties
@@ -1,0 +1,30 @@
+# https://github.com/chriskempson/base16-xresources/blob/master/base16-twilight.light.256.xresources
+# Base16 Twilight
+# Scheme: David Hart (http://hart-dev.com)
+foreground=#464b50
+background=#ffffff
+cursorColor=#464b50
+
+color0=#1e1e1e
+color1=#cf6a4c
+color2=#8f9d6a
+color3=#f9ee98
+color4=#7587a6
+color5=#9b859d
+color6=#afc4db
+color7=#a7a7a7
+color8=#5f5a60
+color9=#cf6a4c
+color10=#8f9d6a
+color11=#f9ee98
+color12=#7587a6
+color13=#9b859d
+color14=#afc4db
+color15=#ffffff
+
+color16=#cda869
+color17=#9b703f
+color18=#323537
+color19=#464b50
+color20=#838184
+color21=#c3c3c3


### PR DESCRIPTION
Because original base16 color scheme has already 256 color scheme, so I don't add repeatedly. 

BTW, because Termux support 256 color scheme, so should remove the '256' from color scheme file name?