### PR TITLE
Update base16 Monokai theme (color17)

### DIFF
--- a/app/src/main/assets/colors/base16-monokai-dark.properties
+++ b/app/src/main/assets/colors/base16-monokai-dark.properties
@@ -22,7 +22,7 @@ color14=      #a1efe4
 color15=      #f9f8f5
 
 color16=      #fd971f
-color17=      #ae81ff
+color17=      #cc6633
 color18=      #383830
 color19=      #49483e
 color20=      #a59f85

--- a/app/src/main/assets/colors/base16-monokai-dark.properties
+++ b/app/src/main/assets/colors/base16-monokai-dark.properties
@@ -1,4 +1,4 @@
-# https://github.com/chriskempson/base16-xresources/blob/master/base16-monokai.dark.256.xresources
+# https://github.com/chriskempson/base16-xresources/blob/master/xresources/base16-monokai-256.Xresources
 foreground=   #f8f8f2
 background=   #272822
 cursor=  #f8f8f2


### PR DESCRIPTION
Based on the [original template](https://github.com/chriskempson/base16-xresources/blob/master/xresources/base16-monokai-256.Xresources#L50), the correct color17 should be base0F (#cc6633), not base0E (#ae81ff).

This PR adds back the dark shade of orange, currently missing on this theme.