### PR TITLE
Add gnometerm-new colorscheme

### DIFF
--- a/app/src/main/assets/colors/gnometerm-new.properties
+++ b/app/src/main/assets/colors/gnometerm-new.properties
@@ -1,0 +1,19 @@
+# Gnome terminal 42 coloscheme
+# https://github.com/termux/termux-styling/issues/164
+
+color0: #171421
+color1: #c01c28
+color2: #26a269
+color3: #a2734c
+color4: #12488b
+color5: #a347ba
+color6: #2aa1b3
+color7: #d0cfcc
+color8: #5e5c64
+color9: #f66151
+color10: #33d17a
+color11: #e9ad0c
+color12: #2a7bde
+color13: #c061cb
+color14: #33c7de
+color15: #ffffff

--- a/app/src/main/assets/colors/gruvbox-material-dark-hard.properties
+++ b/app/src/main/assets/colors/gruvbox-material-dark-hard.properties
@@ -1,0 +1,26 @@
+background: #1D2021
+foreground: #D4BE98
+
+color0:  #665C54
+color8:  #928374
+
+color1:  #EA6962
+color9:  #EA6962
+
+color2:  #A9B665
+color10: #A9B665
+
+color3:  #D8A657
+color11: #D8A657
+
+color4:  #7DAEA3
+color12: #7DAEA3
+
+color5:  #D3869B
+color13: #D3869B
+
+color6:  #89B482
+color14: #89B482
+
+color7:  #D4BE98
+color15: #D4BE98

--- a/app/src/main/assets/colors/gruvbox-material-dark-medium.properties
+++ b/app/src/main/assets/colors/gruvbox-material-dark-medium.properties
@@ -1,0 +1,26 @@
+background: #282828
+foreground: #D4BE98
+
+color0:  #665C54
+color8:  #928374
+
+color1:  #EA6962
+color9:  #EA6962
+
+color2:  #A9B665
+color10: #A9B665
+
+color3:  #D8A657
+color11: #D8A657
+
+color4:  #7DAEA3
+color12: #7DAEA3
+
+color5:  #D3869B
+color13: #D3869B
+
+color6:  #89B482
+color14: #89B482
+
+color7:  #D4BE98
+color15: #D4BE98

--- a/app/src/main/assets/colors/gruvbox-material-dark-soft.properties
+++ b/app/src/main/assets/colors/gruvbox-material-dark-soft.properties
@@ -1,0 +1,26 @@
+background: #32302F
+foreground: #D4BE98
+
+color0:  #665C54
+color8:  #928374
+
+color1:  #EA6962
+color9:  #EA6962
+
+color2:  #A9B665
+color10: #A9B665
+
+color3:  #D8A657
+color11: #D8A657
+
+color4:  #7DAEA3
+color12: #7DAEA3
+
+color5:  #D3869B
+color13: #D3869B
+
+color6:  #89B482
+color14: #89B482
+
+color7:  #D4BE98
+color15: #D4BE98

--- a/app/src/main/assets/colors/gruvbox-material-light-hard.properties
+++ b/app/src/main/assets/colors/gruvbox-material-light-hard.properties
@@ -1,0 +1,26 @@
+background: #F9F5D7
+foreground: #654735
+
+color0:  #504945
+color8:  #504945
+
+color1:  #C14A4A
+color9:  #C14A4A
+
+color2:  #6C782E
+color10: #6C782E
+
+color3:  #B47109
+color11: #B47109
+
+color4:  #45707A
+color12: #45707A
+
+color5:  #945E80
+color13: #945E80
+
+color6:  #4C7A5D
+color14: #4C7A5D
+
+color7:  #D4BE98
+color15: #D4BE98

--- a/app/src/main/assets/colors/gruvbox-material-light-medium.properties
+++ b/app/src/main/assets/colors/gruvbox-material-light-medium.properties
@@ -1,0 +1,26 @@
+background: #FBF1C7
+foreground: #654735
+
+color0:  #504945
+color8:  #504945
+
+color1:  #C14A4A
+color9:  #C14A4A
+
+color2:  #6C782E
+color10: #6C782E
+
+color3:  #B47109
+color11: #B47109
+
+color4:  #45707A
+color12: #45707A
+
+color5:  #945E80
+color13: #945E80
+
+color6:  #4C7A5D
+color14: #4C7A5D
+
+color7:  #D4BE98
+color15: #D4BE98

--- a/app/src/main/assets/colors/gruvbox-material-light-soft.properties
+++ b/app/src/main/assets/colors/gruvbox-material-light-soft.properties
@@ -1,0 +1,26 @@
+background: #F2E5BC
+foreground: #654735
+
+color0:  #504945
+color8:  #504945
+
+color1:  #C14A4A
+color9:  #C14A4A
+
+color2:  #6C782E
+color10: #6C782E
+
+color3:  #B47109
+color11: #B47109
+
+color4:  #45707A
+color12: #45707A
+
+color5:  #945E80
+color13: #945E80
+
+color6:  #4C7A5D
+color14: #4C7A5D
+
+color7:  #D4BE98
+color15: #D4BE98


### PR DESCRIPTION
New Gnome terminal colorscheme on version >=42

Fixes: #164