### PR TITLE
Updated NerdFonts to v3.0.2

### DIFF
--- a/setup-nerd-fonts.sh
+++ b/setup-nerd-fonts.sh
@@ -2,69 +2,51 @@
 set -e -u
 
 getNerdFont() {
-	commit=12a523c32d55bdde88074e5b09e2b2e1eb9b5342
-	url="https://github.com/ryanoasis/nerd-fonts/raw/$commit/patched-fonts/${2}"
-	local_file=app/src/main/assets/fonts/$1.ttf
-	echo "Fetching $url ..."
+	local font_name="${1}"
+	local font_file="${2}"
+
+	local tag="v3.0.2"
+	local url="https://github.com/ryanoasis/nerd-fonts/raw/${tag}/patched-fonts/${font_name}/${font_file}"
+
+	local local_file="app/src/main/assets/fonts/${font_name}.ttf"
+	# Report which font is being downloaded, and keep a running count.
+	echo "Fetching ${url} ... [$(( ++font_counter ))/${#fonts[@]}]"
 	curl -fLo "${local_file}" "${url}"
 }
 
-getNerdFont Anonymous-Pro \
-	"AnonymousPro/complete/Anonymice%20Nerd%20Font%20Complete%20Mono.ttf"
+declare -A fonts=( # [font-name]='path/to/file.ttf'
+	[AnonymousPro]='Regular/AnonymiceProNerdFontMono-Regular.ttf'
+	[DejaVuSansMono]='Regular/DejaVuSansMNerdFontMono-Regular.ttf'
+	[FantasqueSansMono]='Regular/FantasqueSansMNerdFontMono-Regular.ttf'
+	[FiraCode]='Regular/FiraCodeNerdFontMono-Regular.ttf'
+	[FiraMono]='Regular/FiraMonoNerdFontMono-Regular.otf'
+	[Go-Mono]='Regular/GoMonoNerdFontMono-Regular.ttf'
+	[Hack]='Regular/HackNerdFontMono-Regular.ttf'
+	[Hermit]='Regular/HurmitNerdFontMono-Regular.otf'
+	[Inconsolata]='InconsolataNerdFontMono-Regular.ttf'
+	[Iosevka]='Regular/IosevkaNerdFontMono-Regular.ttf'
+	[LiberationMono]='LiterationMonoNerdFontMono-Regular.ttf'
+	[Meslo]='L/Regular/MesloLGLNerdFontMono-Regular.ttf'
+	[Monofur]='Regular/MonofurNerdFontMono-Regular.ttf'
+	[Monoid]='Regular/MonoidNerdFontMono-Regular.ttf'
+	[OpenDyslexic]='Mono-Regular/OpenDyslexicMNerdFontMono-Regular.otf'
+	[RobotoMono]='Regular/RobotoMonoNerdFontMono-Regular.ttf'
+	[SourceCodePro]='Regular/SauceCodeProNerdFontMono-Regular.ttf'
+	[Terminus]='Regular/TerminessNerdFontMono-Regular.ttf'
+	[UbuntuMono]='Regular/UbuntuMonoNerdFontMono-Regular.ttf'
+	[VictorMono]='Regular/VictorMonoNerdFontMono-Regular.ttf'
+)
 
-getNerdFont DejaVu \
-	"DejaVuSansMono/Regular/complete/DejaVu%20Sans%20Mono%20Nerd%20Font%20Complete%20Mono.ttf"
+# Starting log message
+echo -e "\nDownloading ${#fonts[@]} NerdFonts from github.com/ryanoasis/nerd-fonts\n"
 
-getNerdFont Fantasque \
-	"FantasqueSansMono/Regular/complete/Fantasque%20Sans%20Mono%20Regular%20Nerd%20Font%20Complete%20Mono.ttf"
+font_counter='0'
+for font in "${!fonts[@]}"; do
+	font_path="${fonts[${font}]}"
+	getNerdFont "${font}" "${font_path}"
+done
 
-getNerdFont FiraCode \
-	"FiraCode/Regular/complete/Fira%20Code%20Regular%20Nerd%20Font%20Complete%20Mono.ttf"
+# Ending log message
+echo -e "\nDownloaded ${font_counter}/${#fonts[*]} Fonts.\n"
 
-getNerdFont Fira \
-	"FiraMono/Regular/complete/Fura%20Mono%20Regular%20Nerd%20Font%20Complete%20Mono.otf"
-
-getNerdFont Go \
-	"Go-Mono/Regular/complete/Go%20Mono%20Nerd%20Font%20Complete%20Mono.ttf"
-
-getNerdFont Hack \
-	"Hack/Regular/complete/Hack%20Regular%20Nerd%20Font%20Complete%20Mono.ttf"
-
-getNerdFont Hermit \
-	"Hermit/Medium/complete/Hurmit%20Medium%20Nerd%20Font%20Complete%20Mono.otf"
-
-getNerdFont Inconsolata \
-	"InconsolataLGC/Regular/complete/Inconsolata%20LGC%20Nerd%20Font%20Complete%20Mono.ttf"
-
-getNerdFont Iosevka \
-	"Iosevka/Regular/complete/Iosevka%20Nerd%20Font%20Complete%20Mono.ttf"
-
-getNerdFont LiberationMono \
-	"LiberationMono/complete/Literation%20Mono%20Nerd%20Font%20Complete%20Mono.ttf"
-
-getNerdFont Meslo \
-	"Meslo/L/Regular/complete/Meslo%20LG%20L%20Regular%20Nerd%20Font%20Complete%20Mono.ttf"
-
-getNerdFont Monofur \
-	"Monofur/Regular/complete/monofur%20Nerd%20Font%20Complete%20Mono.ttf"
-
-getNerdFont Monoid \
-	"Monoid/Regular/complete/Monoid%20Regular%20Nerd%20Font%20Complete%20Mono.ttf"
-
-getNerdFont OpenDyslexic \
-	"OpenDyslexic/Mono-Regular/complete/OpenDyslexicMono%20Regular%20Nerd%20Font%20Complete%20Mono.otf"
-
-getNerdFont Roboto \
-	"RobotoMono/Regular/complete/Roboto%20Mono%20Nerd%20Font%20Complete%20Mono.ttf"
-
-getNerdFont Source-Code-Pro \
-	"SourceCodePro/Regular/complete/Sauce%20Code%20Pro%20Nerd%20Font%20Complete%20Mono.ttf"
-
-getNerdFont Terminus \
-	"Terminus/terminus-ttf-4.40.1/Regular/complete/Terminess%20(TTF)%20Nerd%20Font%20Complete%20Mono.ttf"
-
-getNerdFont Ubuntu \
-	"UbuntuMono/Regular/complete/Ubuntu%20Mono%20Nerd%20Font%20Complete%20Mono.ttf"
-
-getNerdFont VictorMono \
-	"VictorMono/Regular/complete/Victor%20Mono%20Regular%20Nerd%20Font%20Complete%20Mono.ttf"
+unset 'fonts[@]' 'font' 'font_path' 'font_counter'


### PR DESCRIPTION
As of v3.0.0 NerdFonts has dropped a set of erroneous glyphs in the range `U+F500` - `U+FD46`.
Which was previously overlapping with the Unicode ranges dedicated for:
- `CJK Compatibility Ideographs`
- `Alphabetic Presentation Forms` and
- `Arabic Presentation Forms-A`

For further details see the upstream [issue](https://github.com/ryanoasis/nerd-fonts/issues/365) and [v3.0.0 release](https://github.com/ryanoasis/nerd-fonts/releases/tag/v3.0.0).

Additionally the 3.x.x release of NerdFonts introduced breaking changes to the naming conventions of the provided patched fonts.
As such I have updated the script with the new names and subdirectories of the fonts.
I have also taken this opportunity to reformat the script in a more concise, easier to maintain and extend, fashion.