### PR TITLE
TokyoNight file cleanup

### DIFF
--- a/app/src/main/assets/colors/tokyonight-day.properties
+++ b/app/src/main/assets/colors/tokyonight-day.properties
@@ -1,16 +1,15 @@
-## name: Tokyo Night Day
+## Name: TokyoNight Day
 
 # Special
- background = #e1e2e7
- foreground = #3760bf
- cursor = #3760bf
-# White
+foreground = #3760bf
+background = #e1e2e7
+cursor = #3760bf
+# Black/Grey
 color0 = #e9e9ed
 color8 = #a1a6c5
 # Red
 color1 = #f52a65
 color9 = #f52a65
-color17 = #c64343
 # Green
 color2 = #587539
 color10 = #587539
@@ -20,13 +19,15 @@ color11 = #8c6c3e
 # Blue
 color4 = #2e7de9
 color12 = #2e7de9
-color7 = #6172b0
-color15 = #3760bf
-# Purple
+# Magenta
 color5 = #9854f1
 color13 = #9854f1
 # Cyan
 color6 = #007197
 color14 = #007197
-# Orange
+# White/Grey
+color7 = #6172b0
+color15 = #3760bf
+# Other
 color16 = #b15c00
+color17 = #c64343

--- a/app/src/main/assets/colors/tokyonight-night.properties
+++ b/app/src/main/assets/colors/tokyonight-night.properties
@@ -1,16 +1,15 @@
-## Name: Tokyo Night Dark
+## Name: TokyoNight
 
 # Special
 foreground = #c0caf5
-cursor = #c0caf5
 background = #1a1b26
-# Black
-color0 = #15161E
+cursor = #c0caf5
+# Black/Grey
+color0 = #15161e
 color8 = #414868
 # Red
 color1 = #f7768e
 color9 = #f7768e
-color17 = #db4b4b
 # Green
 color2 = #9ece6a
 color10 = #9ece6a
@@ -20,14 +19,15 @@ color11 = #e0af68
 # Blue
 color4 = #7aa2f7
 color12 = #7aa2f7
-# Purple
+# Magenta
 color5 = #bb9af7
 color13 = #bb9af7
 # Cyan
-color14 = #7dcfff
 color6 = #7dcfff
-# White
+color14 = #7dcfff
+# White/Grey
 color7 = #a9b1d6
 color15 = #c0caf5
-# Orange
+# Other
 color16 = #ff9e64
+color17 = #db4b4b


### PR DESCRIPTION
Cleaned up the formatting and comments in the TokyoNight color scheme files.

Also renamed `tokyonight-dark.properties` to `tokyonight-night.properties`, as per how [upstream](/folke/tokyonight.nvim/tree/main/extras/kitty) handles it.

(I was also going to add the "Moon" and "Storm" variants, but ravener already has PR #222 open for that.)